### PR TITLE
Fix latest_majors_finder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,16 @@
 
 First, thank you for contributing!
 
-It is easy, please run `bin/update` and [send a Pull Request][send-a-pr].
+## Running tests
+
+```
+$ ruby test/*.rb
+```
+
+All tests should pass.
+
+## Update data of this repository
+
+Please run `bin/update` and [send a Pull Request][send-a-pr].
 
 [send-a-pr]: https://help.github.com/desktop/guides/contributing/sending-a-pull-request/

--- a/bin/update
+++ b/bin/update
@@ -5,6 +5,7 @@ Signal.trap("INT") { abort }
 
 require "http"
 require "version_sorter"
+require_relative "../latest_majors_finder"
 
 class RubyGemClient
   ENDPOINT = "https://rubygems.org/api/v1/versions/rails.json"
@@ -12,22 +13,6 @@ class RubyGemClient
   def self.get_rails_info
     JSON.parse(HTTP.get(ENDPOINT))
   end
-end
-
-class LatestMajorsFinder
-  def initialize(sorted_versions)
-    @sorted_versions = sorted_versions
-  end
-
-  def call
-    sorted_versions.group_by do |version|
-      version.split(".")[0..1].join
-    end.map { |lead, versions| VersionSorter.sort(versions).last }
-  end
-
-  private
-
-  attr_reader :sorted_versions
 end
 
 class FileManager

--- a/latest_majors_finder.rb
+++ b/latest_majors_finder.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class LatestMajorsFinder
+  def initialize(sorted_versions)
+    @sorted_versions = sorted_versions
+  end
+
+  def call
+    sorted_versions_group.map do |lead, sorted_versions|
+      find_major(sorted_versions)
+    end
+  end
+
+  private
+
+  attr_reader :sorted_versions
+
+  # {
+  #   "08" => %w(0.8.0 0.8.5),
+  #   ...
+  #   "52" => %w(5.2.0.beta1 5.2.0.beta2 5.2.0.rc1 5.2.0.rc2 5.2.0 5.2.1.rc1)
+  # }
+  def sorted_versions_group
+    @_sorted_versions_group ||= begin
+      sorted_versions.group_by do |version|
+        version.split(".").first(2).join
+      end
+    end
+  end
+
+  def find_major(sorted_versions)
+    sorted_versions.reverse.find do |version|
+      !prerelease?(version)
+    end
+  end
+
+  def prerelease?(version)
+    Gem::Version.new(version).prerelease?
+  end
+end

--- a/test/latest_major_finder_test.rb
+++ b/test/latest_major_finder_test.rb
@@ -1,0 +1,38 @@
+require_relative "../latest_majors_finder"
+
+sorted_rails_52 = %w(5.2.0.beta1 5.2.0.beta2 5.2.0.rc1 5.2.0.rc2 5.2.0 5.2.1.rc1)
+
+result = LatestMajorsFinder.new(sorted_rails_52).call
+
+if result != ["5.2.0"]
+  abort "FAILED: Latest major given 5.2.x data should be 5.2.0."
+else
+  puts "TEST PASSED"
+end
+
+sorted_rails_51 = %w(
+  5.1.0.beta1
+  5.1.0.rc1
+  5.1.0.rc2
+  5.1.0
+  5.1.1
+  5.1.2.rc1
+  5.1.2
+  5.1.3.rc1
+  5.1.3.rc2
+  5.1.3.rc3
+  5.1.3
+  5.1.4.rc1
+  5.1.4
+  5.1.5.rc1
+  5.1.5
+  5.1.6
+)
+
+result = LatestMajorsFinder.new(sorted_rails_51).call
+
+if result != ["5.1.6"]
+  abort "FAILED: Latest major given 5.1.x data should be 5.1.6."
+else
+  puts "TEST PASSED"
+end


### PR DESCRIPTION
81afdcee mistakenly took 5.2.1.rc1 as latest major instead of 5.2.0

The fix is to exclude prerelease.